### PR TITLE
sharing same .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 codex/.env
+.vscode
+.idea

--- a/codex/.env.example
+++ b/codex/.env.example
@@ -1,0 +1,10 @@
+# example variables from environment. add them into the desired .env file
+
+# variables for backend
+
+PORT=8000
+KEY=value
+
+# variables for frontend
+
+VITE_API_URL=http://localhost:8000

--- a/codex/package.json
+++ b/codex/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "server": "nodemon server.js",
+    "server": "nodemon -r dotenv-flow/config server.js",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview"
@@ -13,7 +13,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
-    "dotenv": "^16.3.1",
+    "dotenv-flow": "^3.2.0",
     "express": "^4.18.2",
     "nodemon": "^3.0.1",
     "react": "^18.2.0",

--- a/codex/server.js
+++ b/codex/server.js
@@ -1,20 +1,14 @@
-const PORT = 8000
 import express from 'express';
 import cors from 'cors'
 const app = express()
 app.use(express.json())
 app.use(cors())
 
-
-const KEY = "Here is my special key that I've place here so I can develop";
-console.log(process.env.REACT_APP_API_KEY)
-console.log(import.meta.env.VITE_API_KEY)
-
 app.post('/completions', async (req, res) => {
     const options = {
         method: "post",
         headers: {
-            "Authorization": `Bearer ${KEY}`,
+            "Authorization": `Bearer ${process.env.KEY}`,
             "Content-Type": "application/json"
         },
         body: JSON.stringify({
@@ -23,7 +17,7 @@ app.post('/completions', async (req, res) => {
                 role: 'user',
                 content: req.body.message
             }],
-        })       
+        })
     }
 
     try {
@@ -35,4 +29,4 @@ app.post('/completions', async (req, res) => {
     }
 })
 
-app.listen(PORT, () => console.log('your server is running on port ' + PORT))
+app.listen(process.env.PORT, () => console.log('your server is running on port ' + process.env.PORT))

--- a/codex/src/App.jsx
+++ b/codex/src/App.jsx
@@ -9,16 +9,16 @@ import Generator from './app/components/views/generator/Generator'
 function App() {
 
   return (
-    <body>
-      <Sidebar /> 
-      <main> 
+    <>
+      <Sidebar />
+      <main>
         <Welcome />
         <Liederen />
         <Generator />
         {/* <Routes>
         </Routes> */}
       </main>
-    </body>
+    </>
   )
 }
 

--- a/codex/src/app/components/views/generator/Generator.jsx
+++ b/codex/src/app/components/views/generator/Generator.jsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 
 const Generator = () => {
 
-    const [value, setValue] = useState(null)
+    const [value, setValue] = useState("")
     const [message, setMessage] = useState(null)
     const [request, setRequest] = useState('')
     const [answer, setAnswer] = useState('')
@@ -24,7 +24,7 @@ const Generator = () => {
         }
 
         try {
-           const response =  await fetch('http://localhost:8000/completions', options)
+           const response =  await fetch(`${import.meta.env.VITE_API_URL}/completions`, options)
            const data = await response.json()
            setMessage(data.choices[0].message)
            setAnswer(data.choices[0].message.content)
@@ -51,7 +51,7 @@ const Generator = () => {
           </div>
         );
       }
-    
+
 
     return (
         <>

--- a/codex/yarn.lock
+++ b/codex/yarn.lock
@@ -860,10 +860,22 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv-flow@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv-flow/-/dotenv-flow-3.2.0.tgz#a5d79dd60ddb6843d457a4874aaf122cf659a8b7"
+  integrity sha512-GEB6RrR4AbqDJvNSFrYHqZ33IKKbzkvLYiD5eo4+9aFXr4Y4G+QaFrB/fNp0y6McWBmvaPn3ZNjIufnj8irCtg==
+  dependencies:
+    dotenv "^8.0.0"
+
 dotenv@^16.3.1:
   version "16.3.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
   integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
+dotenv@^8.0.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
+  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 ee-first@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
![image](https://github.com/Stef-Verniers/BAP/assets/556695/6d733a5f-2e92-41ad-b25d-359e23818e9e)

- for server use `process.env.VARIABLE_NAME`
- for client/vite go with `import.meta.env.VITE_VARIABLE_NAME`

replace `dotenv` with `dotenv-flow` in case you wish to have several  `.env` files per environment (i.e. whaterver your NODE_ENV assumes: `.env.development`, `.env.production`, `.env.test` and so on)